### PR TITLE
Added Modupdate for steam workshop mods

### DIFF
--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -23,9 +23,7 @@ namespace WindowsGSM.Plugins
         };
 
         // - Standard Constructor and properties
-        public ConanExiles(ServerConfig serverData) : base(serverData) => base.serverData = _serverData = serverData;
-        private readonly ServerConfig _serverData;
-
+        public ConanExiles(ServerConfig serverData) : base(serverData) => base.serverData =serverData;
         // - Settings properties for SteamCMD installer
         public override bool loginAnonymous => true;
         public override string AppId => "443030";
@@ -50,30 +48,30 @@ namespace WindowsGSM.Plugins
         public async void CreateServerCFG()
         {
             //Download Engine.ini
-            string configPath = Functions.ServerPath.GetServersServerFiles(_serverData.ServerID, @"ConanSandbox\Saved\Config\WindowsServer\Engine.ini");
+            string configPath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, @"ConanSandbox\Saved\Config\WindowsServer\Engine.ini");
             if (await Functions.Github.DownloadGameServerConfig(configPath, FullName))
             {
                 string configText = File.ReadAllText(configPath);
-                configText = configText.Replace("{{ServerName}}", _serverData.ServerName);
-                configText = configText.Replace("{{ServerPassword}}", _serverData.GetRCONPassword());
+                configText = configText.Replace("{{ServerName}}", serverData.ServerName);
+                configText = configText.Replace("{{ServerPassword}}", serverData.GetRCONPassword());
                 File.WriteAllText(configPath, configText);
             }
         }
 
         public async Task<Process> Start()
         {
-            string shipExePath = Functions.ServerPath.GetServersServerFiles(_serverData.ServerID, StartPath);
+            string shipExePath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, StartPath);
             if (!File.Exists(shipExePath))
             {
                 Error = $"{Path.GetFileName(shipExePath)} not found ({shipExePath})";
                 return null;
             }
 
-            string param = string.IsNullOrWhiteSpace(_serverData.ServerIP) ? string.Empty : $" -MultiHome={_serverData.ServerIP}";
-            param += string.IsNullOrWhiteSpace(_serverData.ServerPort) ? string.Empty : $" -Port={_serverData.ServerPort}";
-            param += string.IsNullOrWhiteSpace(_serverData.ServerQueryPort) ? string.Empty : $" -QueryPort={_serverData.ServerQueryPort}";
-            param += string.IsNullOrWhiteSpace(_serverData.ServerMaxPlayer) ? string.Empty : $" -MaxPlayers={_serverData.ServerMaxPlayer}";
-            param += $" {_serverData.ServerParam}" + (!AllowsEmbedConsole ? " -log" : string.Empty);
+            string param = string.IsNullOrWhiteSpace(serverData.ServerIP) ? string.Empty : $" -MultiHome={serverData.ServerIP}";
+            param += string.IsNullOrWhiteSpace(serverData.ServerPort) ? string.Empty : $" -Port={serverData.ServerPort}";
+            param += string.IsNullOrWhiteSpace(serverData.ServerQueryPort) ? string.Empty : $" -QueryPort={serverData.ServerQueryPort}";
+            param += string.IsNullOrWhiteSpace(serverData.ServerMaxPlayer) ? string.Empty : $" -MaxPlayers={serverData.ServerMaxPlayer}";
+            param += $" {serverData.ServerParam}" + (!serverData.EmbedConsole ? " -log" : string.Empty);
 
             Process p;
             if (!AllowsEmbedConsole)
@@ -107,7 +105,7 @@ namespace WindowsGSM.Plugins
                     },
                     EnableRaisingEvents = true
                 };
-                var serverConsole = new Functions.ServerConsole(_serverData.ServerID);
+                var serverConsole = new Functions.ServerConsole(serverData.ServerID);
                 p.OutputDataReceived += serverConsole.AddOutput;
                 p.ErrorDataReceived += serverConsole.AddOutput;
                 p.Start();

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -18,7 +18,7 @@ namespace WindowsGSM.Plugins
             name = "WindowsGSM.ConanExiles", // WindowsGSM.XXXX
             author = "Soul", //moddownload by raziel7893
             description = "\U0001f9e9 A plugin version of the Conan Exiles Dedicated server for WindowsGSM",
-            version = "1.2",
+            version = "1.3",
             url = "https://github.com/Soulflare3/WindowsGSM.ConanExiles", // Github repository link (Best practice)
             color = "#7a0101" // Color Hex
         };

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -125,15 +125,6 @@ namespace WindowsGSM.Plugins
             return p;
         }
 
-        public new async Task<Process> Update(bool validate = false, string custom = null)
-        {
-            await UpdateMods();
-            var (p, error) = await Installer.SteamCMD.UpdateEx(serverData.ServerID, AppId, validate, custom: custom, loginAnonymous: loginAnonymous);
-
-            Error = error;
-            return p;
-        }
-
         public async Task Stop(Process p)
         {
             await Task.Run(() =>
@@ -148,6 +139,15 @@ namespace WindowsGSM.Plugins
                     Functions.ServerConsole.SendWaitToMainWindow("^c");
                 }
             });
+        }
+
+        public new async Task<Process> Update(bool validate = false, string custom = null)
+        {
+            await UpdateMods();
+            var (p, error) = await Installer.SteamCMD.UpdateEx(serverData.ServerID, AppId, validate, custom: custom, loginAnonymous: loginAnonymous);
+
+            Error = error;
+            return p;
         }
 
         private async Task UpdateMods()

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -19,7 +19,7 @@ namespace WindowsGSM.Plugins
             name = "WindowsGSM.ConanExiles", // WindowsGSM.XXXX
             author = "Raziel7893", //moddownload by raziel7893
             description = "\U0001f9e9 A plugin version of the Conan Exiles Dedicated server for WindowsGSM",
-            version = "1.3.2",
+            version = "1.3.3",
             url = "https://github.com/Raziel7893/WindowsGSM.ConanExiles", // Github repository link (Best practice)
             color = "#7a0101" // Color Hex
         };

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -19,7 +19,7 @@ namespace WindowsGSM.Plugins
             name = "WindowsGSM.ConanExiles", // WindowsGSM.XXXX
             author = "Soul", //moddownload by raziel7893
             description = "\U0001f9e9 A plugin version of the Conan Exiles Dedicated server for WindowsGSM",
-            version = "1.3",
+            version = "1.3.1",
             url = "https://github.com/Soulflare3/WindowsGSM.ConanExiles", // Github repository link (Best practice)
             color = "#7a0101" // Color Hex
         };
@@ -173,12 +173,12 @@ namespace WindowsGSM.Plugins
                         continue;
                     }
                     //clear doubleSlashes
-                    tmpLine = line.Replace("//", "/");
+                    tmpLine = tmpLine.Replace("//", "/");
 
                     var elements = tmpLine.Split('/');
                     if (elements.Length > 3)
                     {
-
+                        mods.Add(new ModInfo { AppId = elements[elements.Length - 3], ModId = elements[elements.Length - 2], FileName = elements[elements.Length - 1] });
                     }
                 }
                 await DownloadMods(mods);
@@ -274,7 +274,9 @@ namespace WindowsGSM.Plugins
         {
             using (Stream source = File.Open(sourcePath, FileMode.Open))
             {
-                using (Stream destination = File.Create(destinationPath))
+                if (File.Exists(destinationPath))
+                    File.Delete(destinationPath);
+                using (Stream destination = File.Create(destinationPath, 4096, FileOptions.Asynchronous))
                 {
                     await source.CopyToAsync(destination);
                 }

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -147,6 +147,7 @@ namespace WindowsGSM.Plugins
             await UpdateMods();
             var (p, error) = await Installer.SteamCMD.UpdateEx(serverData.ServerID, AppId, validate, custom: custom, loginAnonymous: loginAnonymous);
 
+            await Task.Run(() => { p.WaitForExit(); });
             Error = error;
             return p;
         }

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -16,7 +16,7 @@ namespace WindowsGSM.Plugins
         public Plugin Plugin = new Plugin
         {
             name = "WindowsGSM.ConanExiles", // WindowsGSM.XXXX
-            author = "Soul",
+            author = "Soul", //moddownload by raziel7893
             description = "\U0001f9e9 A plugin version of the Conan Exiles Dedicated server for WindowsGSM",
             version = "1.2",
             url = "https://github.com/Soulflare3/WindowsGSM.ConanExiles", // Github repository link (Best practice)
@@ -24,7 +24,7 @@ namespace WindowsGSM.Plugins
         };
 
         // - Standard Constructor and properties
-        public ConanExiles(ServerConfig serverData) : base(serverData) => base.serverData =serverData;
+        public ConanExiles(ServerConfig serverData) : base(serverData) => base.serverData = serverData;
         // - Settings properties for SteamCMD installer
         public override bool loginAnonymous => true;
         public override string AppId => "443030";
@@ -125,9 +125,9 @@ namespace WindowsGSM.Plugins
             return p;
         }
 
-        public async Task<Process> Update(bool validate = false, string custom = null)
+        public new async Task<Process> Update(bool validate = false, string custom = null)
         {
-            UpdateMods();
+            await UpdateMods();
             var (p, error) = await Installer.SteamCMD.UpdateEx(serverData.ServerID, AppId, validate, custom: custom, loginAnonymous: loginAnonymous);
 
             Error = error;
@@ -150,7 +150,7 @@ namespace WindowsGSM.Plugins
             });
         }
 
-        private void UpdateMods()
+        private async Task UpdateMods()
         {
             if (File.Exists(Functions.ServerPath.GetServersServerFiles(serverData.ServerID, ModListFile)))
             {
@@ -169,7 +169,7 @@ namespace WindowsGSM.Plugins
                         mods.Add(new ModInfo { AppId = elements[elements.Length - 3], ModId = elements[elements.Length - 2], FileName = elements[elements.Length - 1] });
                     }
                 }
-                DownloadMods(mods);
+                await DownloadMods(mods);
                 var modlistContent = new StringBuilder();
                 foreach (ModInfo mod in mods)
                 {
@@ -197,7 +197,7 @@ namespace WindowsGSM.Plugins
             }
         }
 
-        private void DownloadMods(List<ModInfo> mods)
+        private async Task DownloadMods(List<ModInfo> mods)
         {
             string _exeFile = "steamcmd.exe";
             string _installPath = ServerPath.GetBin("steamcmd");

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -17,10 +17,10 @@ namespace WindowsGSM.Plugins
         public Plugin Plugin = new Plugin
         {
             name = "WindowsGSM.ConanExiles", // WindowsGSM.XXXX
-            author = "Soul", //moddownload by raziel7893
+            author = "Raziel7893", //moddownload by raziel7893
             description = "\U0001f9e9 A plugin version of the Conan Exiles Dedicated server for WindowsGSM",
-            version = "1.3.1",
-            url = "https://github.com/Soulflare3/WindowsGSM.ConanExiles", // Github repository link (Best practice)
+            version = "1.3.2",
+            url = "https://github.com/Raziel7893/WindowsGSM.ConanExiles", // Github repository link (Best practice)
             color = "#7a0101" // Color Hex
         };
 

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -214,7 +214,9 @@ namespace WindowsGSM.Plugins
             {
                 string dest = Path.Combine(destination, Path.GetFileName(file));
                 //only copy if changed
-                if (new FileInfo(file).CreationTimeUtc > new FileInfo(dest).CreationTimeUtc)
+                if (!File.Exists(dest) ||
+                    new FileInfo(file).Length != new FileInfo(dest).Length ||
+                    new FileInfo(file).CreationTimeUtc > new FileInfo(dest).CreationTimeUtc)
                     await CopyFileAsync(file, dest);
             }
         }

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -7,6 +7,7 @@ using WindowsGSM.GameServer.Engine;
 using WindowsGSM.GameServer.Query;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace WindowsGSM.Plugins
 {
@@ -163,10 +164,21 @@ namespace WindowsGSM.Plugins
                 foreach (string line in lines)
                 {
                     string tmpLine = line.Replace("\\", "/");
+                    if (!tmpLine.Contains('/'))
+                    {
+                        if (tmpLine.Contains('*'))
+                        {
+                            mods.Add(new ModInfo { AppId = string.Empty, ModId = string.Empty, FileName = tmpLine.Replace("*", string.Empty) });
+                        }
+                        continue;
+                    }
+                    //clear doubleSlashes
+                    tmpLine = line.Replace("//", "/");
+
                     var elements = tmpLine.Split('/');
                     if (elements.Length > 3)
                     {
-                        mods.Add(new ModInfo { AppId = elements[elements.Length - 3], ModId = elements[elements.Length - 2], FileName = elements[elements.Length - 1] });
+
                     }
                 }
                 await DownloadMods(mods);
@@ -213,6 +225,7 @@ namespace WindowsGSM.Plugins
             StringBuilder sb = new StringBuilder($"+force_install_dir \"{Functions.ServerPath.GetServersServerFiles(serverData.ServerID)}\" +login anonymous");
             foreach (var mod in mods)
             {
+                //skipp nonsteam entries
                 if (!string.IsNullOrEmpty(mod.AppId) && !string.IsNullOrEmpty(mod.ModId) && !string.IsNullOrEmpty(mod.FileName))
                     sb.Append($" +workshop_download_item {mod.AppId} {mod.ModId}");
             }

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -168,7 +168,7 @@ namespace WindowsGSM.Plugins
                     {
                         if (tmpLine.Contains('*'))
                         {
-                            mods.Add(new ModInfo { AppId = string.Empty, ModId = string.Empty, FileName = tmpLine.Replace("*", string.Empty) });
+                            mods.Add(new ModInfo { AppId = string.Empty, ModId = string.Empty, FileName = tmpLine });
                         }
                         continue;
                     }
@@ -178,14 +178,24 @@ namespace WindowsGSM.Plugins
                     var elements = tmpLine.Split('/');
                     if (elements.Length > 3)
                     {
-                        mods.Add(new ModInfo { AppId = elements[elements.Length - 3], ModId = elements[elements.Length - 2], FileName = elements[elements.Length - 1] });
+                        long tmp = 0;
+                        // check if the ids are relly valid
+                        if (Int64.TryParse(elements[elements.Length - 3], out tmp) && Int64.TryParse(elements[elements.Length - 2], out tmp))
+                        {
+                            mods.Add(new ModInfo { AppId = elements[elements.Length - 3], ModId = elements[elements.Length - 2], FileName = $"*{elements[elements.Length - 1]}" });
+                            continue;
+                        }
                     }
+
+                    //just keep the line as is, just ignored by the downloader
+                    mods.Add(new ModInfo { AppId = string.Empty, ModId = string.Empty, FileName = tmpLine });
                 }
+
                 await DownloadMods(mods);
                 var modlistContent = new StringBuilder();
                 foreach (ModInfo mod in mods)
                 {
-                    modlistContent.AppendLine($"*{mod.FileName}");
+                    modlistContent.AppendLine($"{mod.FileName}");
                 }
 
                 await CopyModPaksAsync(modDestFolder);

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -81,7 +81,7 @@ namespace WindowsGSM.Plugins
             param += string.IsNullOrWhiteSpace(serverData.ServerPort) ? string.Empty : $" -Port={serverData.ServerPort}";
             param += string.IsNullOrWhiteSpace(serverData.ServerQueryPort) ? string.Empty : $" -QueryPort={serverData.ServerQueryPort}";
             param += string.IsNullOrWhiteSpace(serverData.ServerMaxPlayer) ? string.Empty : $" -MaxPlayers={serverData.ServerMaxPlayer}";
-            param += $" {serverData.ServerParam}" + (!serverData.EmbedConsole ? " -log" : string.Empty);
+            param += $" {serverData.ServerParam}" + (serverData.EmbedConsole ? " -log" : string.Empty);
 
             Process p;
             if (!AllowsEmbedConsole)

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -19,7 +19,7 @@ namespace WindowsGSM.Plugins
             name = "WindowsGSM.ConanExiles", // WindowsGSM.XXXX
             author = "Raziel7893", //moddownload by raziel7893
             description = "\U0001f9e9 A plugin version of the Conan Exiles Dedicated server for WindowsGSM",
-            version = "1.3.3",
+            version = "1.4.0",
             url = "https://github.com/Raziel7893/WindowsGSM.ConanExiles", // Github repository link (Best practice)
             color = "#7a0101" // Color Hex
         };

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -28,7 +28,7 @@ namespace WindowsGSM.Plugins
         public ConanExiles(ServerConfig serverData) : base(serverData) => base.serverData = serverData;
         // - Settings properties for SteamCMD installer
         public override bool loginAnonymous => true;
-        public override string AppId => "443030";
+        public override string AppId => "443030 -beta public"; //change to -beta conan-exiles-legacy
         public string GameId => "440900";
         public string ModListFile => "ModList.txt";
 

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -1,13 +1,14 @@
 ﻿using System;
-using System.Text;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using WindowsGSM.Functions;
 using WindowsGSM.GameServer.Engine;
 using WindowsGSM.GameServer.Query;
-using System.IO;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace WindowsGSM.Plugins
 {
@@ -126,18 +127,14 @@ namespace WindowsGSM.Plugins
             return p;
         }
 
+        // - Stop server function
         public async Task Stop(Process p)
         {
             await Task.Run(() =>
             {
-                if (p.StartInfo.CreateNoWindow)
+                if (!SendStopSignal(p))
                 {
-                    p.CloseMainWindow();
-                }
-                else
-                {
-                    Functions.ServerConsole.SetMainWindow(p.MainWindowHandle);
-                    Functions.ServerConsole.SendWaitToMainWindow("^c");
+                    p.Kill();
                 }
             });
         }
@@ -294,6 +291,42 @@ namespace WindowsGSM.Plugins
                     await source.CopyToAsync(destination);
                 }
             }
+        }
+
+        #region preparation of the WindowsAPI to send process shutdown signals
+        internal const int CTRL_C_EVENT = 0;
+        [DllImport("kernel32.dll")]
+        internal static extern bool GenerateConsoleCtrlEvent(uint dwCtrlEvent, uint dwProcessGroupId);
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool AttachConsole(uint dwProcessId);
+        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+        internal static extern bool FreeConsole();
+        [DllImport("kernel32.dll")]
+        static extern bool SetConsoleCtrlHandler(ConsoleCtrlDelegate HandlerRoutine, bool Add);
+        delegate Boolean ConsoleCtrlDelegate(uint CtrlType);
+        #endregion
+        //sends the stop signal to the process
+        public static bool SendStopSignal(Process p)
+        {
+            if (AttachConsole((uint)p.Id))
+            {
+                SetConsoleCtrlHandler(null, true);
+                try
+                {
+                    if (!GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0))
+                    {
+                        return false;
+                    }
+                    p.WaitForExit(10000);
+                }
+                finally
+                {
+                    SetConsoleCtrlHandler(null, false);
+                    FreeConsole();
+                }
+                return true;
+            }
+            return false;
         }
 
     }

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -28,7 +28,7 @@ namespace WindowsGSM.Plugins
         public ConanExiles(ServerConfig serverData) : base(serverData) => base.serverData = serverData;
         // - Settings properties for SteamCMD installer
         public override bool loginAnonymous => true;
-        public override string AppId => "443030 -beta public"; //for legacy: change to -beta conan-exiles-legacy
+        public override string AppId => "443030"; //for legacy: change to "443030 -beta conan-exiles-legacy"
         public string GameId => "440900";
         public string ModListFile => "ModList.txt";
 

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -20,7 +20,7 @@ namespace WindowsGSM.Plugins
             name = "WindowsGSM.ConanExiles", // WindowsGSM.XXXX
             author = "Raziel7893", //moddownload by raziel7893
             description = "\U0001f9e9 A plugin version of the Conan Exiles Dedicated server for WindowsGSM",
-            version = "1.4.0",
+            version = "1.4.1",
             url = "https://github.com/Raziel7893/WindowsGSM.ConanExiles", // Github repository link (Best practice)
             color = "#7a0101" // Color Hex
         };

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -20,7 +20,7 @@ namespace WindowsGSM.Plugins
             name = "WindowsGSM.ConanExiles", // WindowsGSM.XXXX
             author = "Raziel7893", //moddownload by raziel7893
             description = "\U0001f9e9 A plugin version of the Conan Exiles Dedicated server for WindowsGSM",
-            version = "1.4.1",
+            version = "1.4.2",
             url = "https://github.com/Raziel7893/WindowsGSM.ConanExiles", // Github repository link (Best practice)
             color = "#7a0101" // Color Hex
         };

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -78,8 +78,8 @@ namespace WindowsGSM.Plugins
                 return null;
             }
 
-            string param = string.IsNullOrWhiteSpace(serverData.ServerIP) ? string.Empty : $" -MultiHome={serverData.ServerIP}";
-            param += string.IsNullOrWhiteSpace(serverData.ServerPort) ? string.Empty : $" -Port={serverData.ServerPort}";
+            // string param = string.IsNullOrWhiteSpace(serverData.ServerIP) ? string.Empty : $" -MultiHome={serverData.ServerIP}";
+            string param = string.IsNullOrWhiteSpace(serverData.ServerPort) ? string.Empty : $" -Port={serverData.ServerPort}";
             param += string.IsNullOrWhiteSpace(serverData.ServerQueryPort) ? string.Empty : $" -QueryPort={serverData.ServerQueryPort}";
             param += string.IsNullOrWhiteSpace(serverData.ServerMaxPlayer) ? string.Empty : $" -MaxPlayers={serverData.ServerMaxPlayer}";
             param += $" {serverData.ServerParam}" + (serverData.EmbedConsole ? " -log" : string.Empty);

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -263,7 +263,7 @@ namespace WindowsGSM.Plugins
             await RunProcessAsync(p);
         }
 
-        static Task<int> RunProcessAsync(Process p)
+        Task<int> RunProcessAsync(Process p)
         {
             var tcs = new TaskCompletionSource<int>();
 
@@ -274,8 +274,13 @@ namespace WindowsGSM.Plugins
                 tcs.SetResult(p.ExitCode);
                 p.Dispose();
             };
-
+            
+            var serverConsole = new ServerConsole(serverData.ServerID);
+            p.OutputDataReceived += serverConsole.AddOutput;
+            p.ErrorDataReceived += serverConsole.AddOutput;
             p.Start();
+            p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
 
             return tcs.Task;
         }

--- a/ConanExiles.cs/ConanExiles.cs
+++ b/ConanExiles.cs/ConanExiles.cs
@@ -28,7 +28,7 @@ namespace WindowsGSM.Plugins
         public ConanExiles(ServerConfig serverData) : base(serverData) => base.serverData = serverData;
         // - Settings properties for SteamCMD installer
         public override bool loginAnonymous => true;
-        public override string AppId => "443030 -beta public"; //change to -beta conan-exiles-legacy
+        public override string AppId => "443030 -beta public"; //for legacy: change to -beta conan-exiles-legacy
         public string GameId => "440900";
         public string ModListFile => "ModList.txt";
 
@@ -43,7 +43,7 @@ namespace WindowsGSM.Plugins
         public string Port = "7777";
         public string ServerName = "Conan Exiles Dedicated Server";
         public string QueryPort = "27015";
-        public string Defaultmap = "game.db";
+        public string Defaultmap = "Dedicated";    //for legacy : "game.db"
         public string Maxplayers = "40";
         public string Additional = "";
 

--- a/README.md
+++ b/README.md
@@ -63,5 +63,13 @@ Many windowsgsm plugin creators recommend zerotier (should be a free VPN designa
 ### Support
 [WGSM](https://discord.com/channels/590590698907107340/645730252672335893)
 
+### Give Love!
+[Buy me a coffee](https://ko-fi.com/raziel7893)
+
+[Paypal](https://paypal.me/raziel7893)
+
+### License
+This project is licensed under the MIT License - see the <a href="https://github.com/raziel7893/WindowsGSM.Smalland/blob/main/LICENSE">LICENSE.md</a> file for details
+
 ### License
 This project is licensed under the MIT License - see the [LICENSE.md](https://github.com/Soulflare3/WindowsGSM.ConanExiles/blob/master/LICENSE) file for details

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@
 - wgsm will try to load all the mods from steam and copy them into the Mods folder.
 - WGSM Software will freetze as long as the download takes, so don'T freak out. Will try to fix that sometime.
 
+### Official Documentation
+🗃️ https://www.conanexiles.com/dedicated-servers/
+
+### The Game
+🕹️ https://store.steampowered.com/app/440900/Conan_Exiles/
+
+### Dedicated server info
+🖥️ https://steamdb.info/app/443030
 
 ## Requirements
 [WindowsGSM](https://github.com/WindowsGSM/WindowsGSM) >= 1.21.0
@@ -17,6 +25,35 @@
 1. Download the [latest](https://github.com/Soulflare3/WindowsGSM.ConanExiles/releases/latest) release
 1. Move **ConanExiles.cs** folder to **plugins** folder or import the zip from the plugins tab
 1. Click the **[RELOAD PLUGINS]** button or restart WindowsGSM
+
+### Files To Backup
+- Save Gane
+  - WindowsGSM\servers\%ID%\serverfiles\ConanSandbox\Saved
+  - WindowsGSM\servers\%ID%\serverfiles\ConanSandbox\Config
+- WindowsGSM Config
+  - WindowsGSM\servers\%ID%\configs
+
+### Not having an full IPv4 adress ( named CCNAT or DSL Light )
+No game or gameserver supports ipv6 only connections. 
+- You need to either buy one (most VPN services provide that option. A pal uses ovpn.net for his server, I know of nordvpn also providing that. Should both cost around 7€ cheaper half of it, if your already having an VPN)
+- Or you pay a bit more for your internet and take a contract with full ipv4. (depending on your country)
+- There are also tunneling methods, which require acces to a server with a full ipv4. Some small VPS can be obtained, not powerfull enough for the servers themself, but only for forwarding. I think there are some for under 5€), the connection is then done via wireguard. but its a bit configuration heavy to setup) 
+
+Or you connect your friends via VPN to your net and play via local lan then.
+Many windowsgsm plugin creators recommend zerotier (should be a free VPN designated for gaming) , see chapter below (or tailscale, but no howto there)
+
+## How can you play with your friends without port forwarding?
+- Use [zerotier](https://www.zerotier.com/) folow the basic guide and create network
+- Download the client app and join to your network
+- Create static IP address for your host machine
+- Edit WGSM IP Address to your recently created static IP address
+- Give your network ID to your friends
+- After they've joined to your network
+- They can connect using the IP you've created eg: 10.123.17.1:7777
+- Enjoy
+
+### Support
+[WGSM](https://discord.com/channels/590590698907107340/645730252672335893)
 
 ### License
 This project is licensed under the MIT License - see the [LICENSE.md](https://github.com/Soulflare3/WindowsGSM.ConanExiles/blob/master/LICENSE) file for details

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@
 1. Move **ConanExiles.cs** folder to **plugins** folder or import the zip from the plugins tab
 1. Click the **[RELOAD PLUGINS]** button or restart WindowsGSM
 
+## Portforwardings:
+You need this to connect from anywhere outside your local home
+If You don't know How: https://portforward.com/router.htm , search the list for your router and you should get an howto
+- 7777 UDP (gameport)
+- 7778 UDP (should be GamePort +1 if changed)
+- 27016 UDP OR TCP( QueryPort, not sure about the protocol there, should be udp)
+
+
 ### Files To Backup
 - Save Gane
   - WindowsGSM\servers\%ID%\serverfiles\ConanSandbox\Saved

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 🧩 A plugin version of the Conan Exiles Dedicated server for WindowsGSM
 
+## Mods (only steammods possible)
+- Just copy your ModList.txt to the ServerFiles root (click Browse => serverfiles) and click update.
+- wgsm will try to load all the mods from steam and copy them into the Mods folder.
+- WGSM Software will freetze as long as the download takes, so don'T freak out. Will try to fix that sometime.
+
+
 ## Requirements
 [WindowsGSM](https://github.com/WindowsGSM/WindowsGSM) >= 1.21.0
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 - Just copy your ModList.txt to the ServerFiles root (click Browse => serverfiles) and click update.
 - WGSM will try to load all the mods from steam and copy them into the Mods folder.
 - If you need to change the order: edit that file. the Plugin will recreate the ConanExilesSandbox/Mods/Modlist.txt after each update
-- WGSM Software will freetze as long as the download takes, so don'T freak out. Will try to fix that sometime.
 
 ### Official Documentation
 🗃️ https://www.conanexiles.com/dedicated-servers/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 🧩 A plugin version of the Conan Exiles Dedicated server for WindowsGSM
 
-## Mods (only steammods possible)
+## Mod AutoUpdate (only steammods possible)
 - Just copy your ModList.txt to the ServerFiles root (click Browse => serverfiles) and click update.
-- wgsm will try to load all the mods from steam and copy them into the Mods folder.
+- WGSM will try to load all the mods from steam and copy them into the Mods folder.
+- If you need to change the order: edit that file. the Plugin will recreate the ConanExilesSandbox/Mods/Modlist.txt after each update
 - WGSM Software will freetze as long as the download takes, so don'T freak out. Will try to fix that sometime.
 
 ### Official Documentation

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 🧩 A plugin version of the Conan Exiles Dedicated server for WindowsGSM
 
+## legacy conan
+To use the legacy version, open your plugins/ConanExiles.cs/ConanExiles.cs at line 31 and replace the "-beta public" with "-beta conan-exiles-legacy"
+
 ## Mod AutoUpdate (only steammods possible)
 - Just copy your ModList.txt to the ServerFiles root (click Browse => serverfiles) and click update.
 - WGSM will try to load all the mods from steam and copy them into the Mods folder.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 ## Notes
 To use the legacy version https://github.com/Raziel7893/WindowsGSM.ConanExilesLegacy
+- If you get issues with outdated versions:
+  - Got to ConanSandbox\Saved\Config\WindowsServer\Engine
+  - Delete the lines:
+  -  bUseBuildIdOverride=True
+  -  BuildIdOverride=XXXXXXX
 
 ## Mod AutoUpdate (only steammods possible)
 - Just copy your ModList.txt to the ServerFiles root (click Browse => serverfiles) and click update.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Notes
 To use the legacy version https://github.com/Raziel7893/WindowsGSM.ConanExilesLegacy
 - If you get issues with outdated versions:
-  - Got to ConanSandbox\Saved\Config\WindowsServer\Engine
+  - Go to ConanSandbox\Saved\Config\WindowsServer\Engine
   - Delete the lines:
   * bUseBuildIdOverride=True
   * BuildIdOverride=XXXXXXX

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ To use the legacy version https://github.com/Raziel7893/WindowsGSM.ConanExilesLe
 - If you get issues with outdated versions:
   - Got to ConanSandbox\Saved\Config\WindowsServer\Engine
   - Delete the lines:
-  -  bUseBuildIdOverride=True
-  -  BuildIdOverride=XXXXXXX
+  * bUseBuildIdOverride=True
+  * BuildIdOverride=XXXXXXX
 
 ## Mod AutoUpdate (only steammods possible)
 - Just copy your ModList.txt to the ServerFiles root (click Browse => serverfiles) and click update.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,7 @@
 🧩 A plugin version of the Conan Exiles Dedicated server for WindowsGSM
 
 ## Notes
-To use the legacy version
-- open your plugins/ConanExiles.cs/ConanExiles.cs at line 31 and replace the "-beta public" with "-beta conan-exiles-legacy"
-- You also need to change the Servermap to "game.db" 
-To use enhanced for old plugins: change the Server Map (click Edit Config Button) to Dedicated instead of game.db 
+To use the legacy version https://github.com/Raziel7893/WindowsGSM.ConanExilesLegacy
 
 ## Mod AutoUpdate (only steammods possible)
 - Just copy your ModList.txt to the ServerFiles root (click Browse => serverfiles) and click update.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 
 🧩 A plugin version of the Conan Exiles Dedicated server for WindowsGSM
 
-## legacy conan
-To use the legacy version, open your plugins/ConanExiles.cs/ConanExiles.cs at line 31 and replace the "-beta public" with "-beta conan-exiles-legacy"
+## Notes
+To use the legacy version
+- open your plugins/ConanExiles.cs/ConanExiles.cs at line 31 and replace the "-beta public" with "-beta conan-exiles-legacy"
+- You also need to change the Servermap to "game.db" 
+To use enhanced for old plugins: change the Server Map (click Edit Config Button) to Dedicated instead of game.db 
 
 ## Mod AutoUpdate (only steammods possible)
 - Just copy your ModList.txt to the ServerFiles root (click Browse => serverfiles) and click update.


### PR DESCRIPTION

Added functionality to automatically download and update mods according to a Modlist.txt.
The only thing to be done is copy over the automated Modlist.txt from a client to the serverfiles root. 

Excpected format is a full path to the pak file, as the plugin will extract game,ModID and pakFileName from the entry:
`
F:\Games\SteamLibary3\steamapps\workshop\content\440900\880454836/Pippi.pak
`
so a manual *Pippi.pak will not work here. 

the plugin will then copy all *.pak files from the workshop folder to ConanSandbox\Mods and create a shorted modlist.txt from the input file.

mixing workshop mods and other mods should work in the modlist. they will be simply plain copied to the new modlist, if it is not a steam workshop path